### PR TITLE
Add VisitorConverter: uses visitor model for encoding

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -121,6 +121,8 @@ to JSON data <http://wiki.open311.org/JSON_and_XML_Conversion/>`_.
     .. automethod:: element_decode
     .. automethod:: element_encode
 
+.. autoclass:: xmlschema.VisitorConverter
+
 .. autoclass:: xmlschema.ParkerConverter
 
 .. autoclass:: xmlschema.BadgerFishConverter

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -121,7 +121,7 @@ to JSON data <http://wiki.open311.org/JSON_and_XML_Conversion/>`_.
     .. automethod:: element_decode
     .. automethod:: element_encode
 
-.. autoclass:: xmlschema.VisitorConverter
+.. autoclass:: xmlschema.UnorderedConverter
 
 .. autoclass:: xmlschema.ParkerConverter
 

--- a/xmlschema/__init__.py
+++ b/xmlschema/__init__.py
@@ -15,7 +15,7 @@ from .resources import (
 )
 from .xpath import ElementPathMixin
 from .converters import (
-    ElementData, XMLSchemaConverter, VisitorConverter, ParkerConverter, BadgerFishConverter, AbderaConverter, JsonMLConverter
+    ElementData, XMLSchemaConverter, ParkerConverter, BadgerFishConverter, AbderaConverter, JsonMLConverter
 )
 from .documents import validate, to_dict, to_json, from_json
 

--- a/xmlschema/__init__.py
+++ b/xmlschema/__init__.py
@@ -15,7 +15,7 @@ from .resources import (
 )
 from .xpath import ElementPathMixin
 from .converters import (
-    ElementData, XMLSchemaConverter, ParkerConverter, BadgerFishConverter, AbderaConverter, JsonMLConverter
+    ElementData, XMLSchemaConverter, VisitorConverter, ParkerConverter, BadgerFishConverter, AbderaConverter, JsonMLConverter
 )
 from .documents import validate, to_dict, to_json, from_json
 

--- a/xmlschema/converters.py
+++ b/xmlschema/converters.py
@@ -368,7 +368,7 @@ class XMLSchemaConverter(NamespaceMapper):
         return ElementData(tag, text, content, attributes)
 
 
-class VisitorConverter(XMLSchemaConverter):
+class UnorderedConverter(XMLSchemaConverter):
     """
     Same as :class:`XMLSchemaConverter` but :meth:`element_encode` is
     modified so the order of the elements in the encoded output is based on
@@ -380,6 +380,9 @@ class VisitorConverter(XMLSchemaConverter):
     eg.
 
     .. code-block:: python
+
+        import xmlschema
+        from xmlschema.converters import UnorderedConverter
 
         xsd = \"\"\"<?xml version="1.0" encoding="UTF-8"?>
           <schema xmlns:ns="ns" xmlns="http://www.w3.org/2001/XMLSchema"
@@ -394,7 +397,7 @@ class VisitorConverter(XMLSchemaConverter):
             </element>
           </schema>\"\"\"
 
-        schema = xmlschema.XMLSchema(xsd, converter=xmlschema.VisitorConverter)
+        schema = xmlschema.XMLSchema(xsd, converter=UnorderedConverter)
         tree = schema.to_etree(
             {"A": [1, 2], "B": [3, 4]},
         )

--- a/xmlschema/converters.py
+++ b/xmlschema/converters.py
@@ -18,6 +18,7 @@ from .compat import ordered_dict_class, unicode_type
 from .exceptions import XMLSchemaValueError
 from .etree import etree_element, lxml_etree_element, etree_register_namespace, lxml_etree_register_namespace
 from .namespaces import XSI_NAMESPACE
+from .qnames import XSI_TYPE
 from xmlschema.namespaces import NamespaceMapper
 
 ElementData = namedtuple('ElementData', ['tag', 'text', 'content', 'attributes'])
@@ -362,6 +363,184 @@ class XMLSchemaConverter(NamespaceMapper):
                             content.append((ns_name, value))
                     else:
                         content.append((ns_name, value))
+
+        return ElementData(tag, text, content, attributes)
+
+
+class VisitorConverter(XMLSchemaConverter):
+    """
+    Same as :class:`XMLSchemaConverter` but :meth:`element_encode` is
+    modified so the order of the elements in the encoded output is based on
+    the model visitor pattern rather than the order in which the elements
+    were added to the input dictionary. As the order of the input
+    dictionary is not preserved, text between sibling elements will raise
+    an exception.
+
+    eg.
+
+    .. code-block:: python
+
+        xsd = \"\"\"<?xml version="1.0" encoding="UTF-8"?>
+          <schema xmlns:ns="ns" xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="ns" elementFormDefault="unqualified" version="1.0">
+            <element name="foo">
+              <complexType>
+                <sequence minOccurs="1" maxOccurs="2">
+                  <element name="A" type="integer" />
+                  <element name="B" type="integer" />
+                </sequence>
+              </complexType>
+            </element>
+          </schema>\"\"\"
+
+        schema = xmlschema.XMLSchema(xsd, converter=xmlschema.VisitorConverter)
+        tree = schema.to_etree(
+            {"A": [1, 2], "B": [3, 4]},
+        )
+        # Returns equivalent of:
+        # <ns:foo xmlns:ns="ns">
+        #     <A>1</A>
+        #     <B>3</B>
+        #     <A>2</A>
+        #     <B>4</B>
+        # </ns:foo>
+
+    Schemas which contain repeated sequences (``maxOccurs > 1``) of
+    optional elements may be ambiguous using this approach when some of the
+    optional elements are not present. In those cases, decoding and then
+    encoding may not reproduce the original ordering.
+    """
+
+    def element_encode(self, obj, xsd_element, level=0):
+        """
+        Extracts XML decoded data from a data structure for encoding into an ElementTree.
+
+        :param obj: the decoded object.
+        :param xsd_element: the `XsdElement` associated to the decoded data structure.
+        :param level: the level related to the encoding process (0 means the root).
+        :return: an ElementData instance.
+        """
+        from xmlschema.validators.models import ModelVisitor
+
+        if level != 0:
+            tag = xsd_element.name
+        elif not self.preserve_root:
+            tag = xsd_element.qualified_name
+        else:
+            tag = xsd_element.qualified_name
+            try:
+                obj = obj.get(tag, xsd_element.local_name)
+            except (KeyError, AttributeError, TypeError):
+                pass
+
+        if not isinstance(obj, (self.dict, dict)):
+            if xsd_element.type.is_simple() or xsd_element.type.has_simple_content():
+                return ElementData(tag, obj, None, self.dict())
+            else:
+                return ElementData(tag, None, obj, self.dict())
+
+        unmap_qname = self.unmap_qname
+        unmap_attribute_qname = self._unmap_attribute_qname
+        text_key = self.text_key
+        attr_prefix = self.attr_prefix
+        ns_prefix = self.ns_prefix
+        cdata_prefix = self.cdata_prefix
+
+        text = None
+        content_lu = {}
+        attributes = self.dict()
+        for name, value in obj.items():
+            if text_key and name == text_key:
+                text = obj[text_key]
+            elif (cdata_prefix and name.startswith(cdata_prefix)) or \
+                    name[0].isdigit() and cdata_prefix == '':
+                raise XMLSchemaValueError(
+                    "cdata segments are not compatible with the '{}' converter".format(
+                        self.__class__.__name__
+                    )
+                )
+            elif name == ns_prefix:
+                self[''] = value
+            elif name.startswith('%s:' % ns_prefix):
+                self[name[len(ns_prefix) + 1:]] = value
+            elif attr_prefix and name.startswith(attr_prefix):
+                name = name[len(attr_prefix):]
+                attributes[unmap_attribute_qname(name)] = value
+            elif not isinstance(value, (self.list, list)) or not value:
+                content_lu[unmap_qname(name)] = iter([value])
+            elif isinstance(value[0], (self.dict, dict, self.list, list)):
+                content_lu[unmap_qname(name)] = iter(value)
+            else:
+                # `value` is a list but not a list of lists or list of
+                # dicts.
+                ns_name = unmap_qname(name)
+                for xsd_child in xsd_element.type.content_type.iter_elements():
+                    matched_element = xsd_child.match(ns_name, self.get(''))
+                    if matched_element is not None:
+                        if matched_element.type.is_list():
+                            content_lu[unmap_qname(name)] = iter([value])
+                        else:
+                            content_lu[unmap_qname(name)] = iter(value)
+                        break
+                else:
+                    if attr_prefix == '' and ns_name not in attributes:
+                        for xsd_attribute in xsd_element.attributes.values():
+                            if xsd_attribute.is_matching(ns_name):
+                                attributes[ns_name] = value
+                                break
+                        else:
+                            content_lu[unmap_qname(name)] = iter([value])
+                    else:
+                        content_lu[unmap_qname(name)] = iter([value])
+
+        content = []
+        if content_lu:
+            # Get the instance type: xsi:type or the schema's declaration
+            if XSI_TYPE not in attributes:
+                xsd_type = xsd_element.get_type(
+                    ElementData(tag, None, None, attributes)
+                )
+            else:
+                xsi_type = attributes[XSI_TYPE]
+                try:
+                    xsd_type = xsd_element.maps.lookup_type(unmap_qname(xsi_type))
+                except KeyError:
+                    raise Exception("unknown type %r" % xsi_type)
+            model = ModelVisitor(xsd_type.content_type)
+            while model.element is not None:
+                elem_name = None
+                if model.element.name in content_lu:
+                    elem_name = model.element.name
+                else:
+                    for elem in model.element.iter_substitutes():
+                        if elem.name in content_lu:
+                            elem_name = elem.name
+                            break
+
+                match = False
+                if elem_name is not None:
+                    match = True
+                    try:
+                        content.append(
+                            (elem_name, next(content_lu[elem_name]))
+                        )
+                    except StopIteration:
+                        match = False
+                        del content_lu[elem_name]
+
+                if not content_lu:
+                    break
+                # consume the return of advance otherwise we get stuck in an
+                # infinite loop. Checking validity is the responsibility of
+                # `iter_encode`.
+                list(model.advance(match))
+
+            # Append any remaining content onto the end of the data. It's up to
+            # the `iter_encode` functions to decide whether their presence is
+            # an error (validation="lax", etc.).
+            for elem_name, values in content_lu.items():
+                for value in values:
+                    content.append((elem_name, value))
 
         return ElementData(tag, text, content, attributes)
 

--- a/xmlschema/tests/test_validators.py
+++ b/xmlschema/tests/test_validators.py
@@ -1384,7 +1384,7 @@ class XMLSchemaVisitorConverter(xmlschema.XMLSchema):
 class TestEncodingVisitorConverter10(TestEncoding):
     schema_class = XMLSchemaVisitorConverter
 
-    def test_visitor_converter_sequence_in_sequence(self):
+    def test_visitor_converter_repeated_sequence_of_elements(self):
         schema = self.get_schema("""
             <element name="foo">
                 <complexType>

--- a/xmlschema/tests/test_validators.py
+++ b/xmlschema/tests/test_validators.py
@@ -24,9 +24,10 @@ from elementpath import datatypes
 
 import xmlschema
 from xmlschema import (
-    XMLSchemaEncodeError, XMLSchemaValidationError, VisitorConverter,
-    ParkerConverter, BadgerFishConverter, AbderaConverter, JsonMLConverter
+    XMLSchemaEncodeError, XMLSchemaValidationError, ParkerConverter,
+    BadgerFishConverter, AbderaConverter, JsonMLConverter
 )
+from xmlschema.converters import UnorderedConverter
 from xmlschema.compat import unicode_type, ordered_dict_class
 from xmlschema.etree import etree_element, etree_tostring, is_etree_element, ElementTree, \
     etree_elements_assert_equal, lxml_etree, lxml_etree_element
@@ -779,11 +780,11 @@ class TestDecoding(XMLSchemaTestCase):
         self.assertEqual(default_dict_root, {'col:collection': _COLLECTION_DICT})
 
     def test_visitor_converter(self):
-        visitor_dict = self.col_schema.to_dict(self.col_xml_file, converter=VisitorConverter)
+        visitor_dict = self.col_schema.to_dict(self.col_xml_file, converter=UnorderedConverter)
         self.assertEqual(visitor_dict, _COLLECTION_DICT)
 
         visitor_dict_root = self.col_schema.to_dict(
-            self.col_xml_file, converter=VisitorConverter(preserve_root=True))
+            self.col_xml_file, converter=UnorderedConverter(preserve_root=True))
         self.assertEqual(visitor_dict_root, {'col:collection': _COLLECTION_DICT})
 
     def test_parker_converter(self):
@@ -1270,8 +1271,8 @@ class TestEncoding(XMLSchemaTestCase):
         self.check_encode(schema.elements['A'], {'B1': 'abc', 'B2': 10, 'B4': False}, XMLSchemaValidationError)
 
         converter_cls = getattr(self.schema_class, "converter", None)
-        if converter_cls and issubclass(converter_cls, VisitorConverter):
-            # VisitorConverter doesn't use ordered content which makes
+        if converter_cls and issubclass(converter_cls, UnorderedConverter):
+            # UnorderedConverter doesn't use ordered content which makes
             # it incompatible with cdata.
             self.check_encode(
                 xsd_component=schema.elements['A'],
@@ -1304,7 +1305,7 @@ class TestEncoding(XMLSchemaTestCase):
         </complexType>
         """)
         converter_cls = getattr(self.schema_class, "converter", None)
-        if converter_cls and issubclass(converter_cls, VisitorConverter):
+        if converter_cls and issubclass(converter_cls, UnorderedConverter):
             expected = u'<ns:A xmlns:ns="ns">\n<B1>abc</B1>\n<B2>10</B2>\n<B3>true</B3>\n</ns:A>'
         else:
             expected = XMLSchemaChildrenValidationError
@@ -1401,12 +1402,12 @@ class TestEncoding11(TestEncoding):
     schema_class = XMLSchema11
 
 
-class XMLSchemaVisitorConverter(xmlschema.XMLSchema):
-    converter = VisitorConverter
+class XMLSchemaUnorderedConverter(xmlschema.XMLSchema):
+    converter = UnorderedConverter
 
 
-class TestEncodingVisitorConverter10(TestEncoding):
-    schema_class = XMLSchemaVisitorConverter
+class TestEncodingUnorderedConverter10(TestEncoding):
+    schema_class = XMLSchemaUnorderedConverter
 
     def test_visitor_converter_repeated_sequence_of_elements(self):
         schema = self.get_schema("""
@@ -1428,12 +1429,12 @@ class TestEncodingVisitorConverter10(TestEncoding):
         self.assertEqual(vals, ['1', '3', '2', '4'])
 
 
-class XMLSchema11VisitorConverter(XMLSchema11):
-    converter = VisitorConverter
+class XMLSchema11UnorderedConverter(XMLSchema11):
+    converter = UnorderedConverter
 
 
-class TestEncodingVisitorConverter11(TestEncoding):
-    schema_class = XMLSchema11VisitorConverter
+class TestEncodingUnorderedConverter11(TestEncoding):
+    schema_class = XMLSchema11UnorderedConverter
 
 
 # Creates decoding/encoding tests classes from XML files

--- a/xmlschema/tests/test_validators.py
+++ b/xmlschema/tests/test_validators.py
@@ -1292,6 +1292,30 @@ class TestEncoding(XMLSchemaTestCase):
                 expected=XMLSchemaValidationError, indent=0, cdata_prefix='#'
             )
 
+    def test_encode_unordered_content(self):
+        schema = self.get_schema("""
+        <element name="A" type="ns:A_type" />
+        <complexType name="A_type">
+            <sequence>
+                <element name="B1" type="string"/>
+                <element name="B2" type="integer"/>
+                <element name="B3" type="boolean"/>
+            </sequence>
+        </complexType>
+        """)
+        converter_cls = getattr(self.schema_class, "converter", None)
+        if converter_cls and issubclass(converter_cls, VisitorConverter):
+            expected = u'<ns:A xmlns:ns="ns">\n<B1>abc</B1>\n<B2>10</B2>\n<B3>true</B3>\n</ns:A>'
+        else:
+            expected = XMLSchemaChildrenValidationError
+
+        self.check_encode(
+            xsd_component=schema.elements['A'],
+            data=ordered_dict_class([('B2', 10), ('B1', 'abc'), ('B3', True)]),
+            expected=expected,
+            indent=0, cdata_prefix='#'
+        )
+
     def test_encode_datetime(self):
         xs = self.get_schema('<element name="dt" type="dateTime"/>')
 

--- a/xmlschema/tests/test_validators.py
+++ b/xmlschema/tests/test_validators.py
@@ -24,12 +24,13 @@ from elementpath import datatypes
 
 import xmlschema
 from xmlschema import (
-    XMLSchemaEncodeError, XMLSchemaValidationError, ParkerConverter,
-    BadgerFishConverter, AbderaConverter, JsonMLConverter
+    XMLSchemaEncodeError, XMLSchemaValidationError, VisitorConverter,
+    ParkerConverter, BadgerFishConverter, AbderaConverter, JsonMLConverter
 )
 from xmlschema.compat import unicode_type, ordered_dict_class
 from xmlschema.etree import etree_element, etree_tostring, is_etree_element, ElementTree, \
     etree_elements_assert_equal, lxml_etree, lxml_etree_element
+from xmlschema.exceptions import XMLSchemaValueError
 from xmlschema.validators.exceptions import XMLSchemaChildrenValidationError
 from xmlschema.helpers import local_name
 from xmlschema.qnames import XSI_TYPE
@@ -777,6 +778,14 @@ class TestDecoding(XMLSchemaTestCase):
         default_dict_root = self.col_schema.to_dict(self.col_xml_file, preserve_root=True)
         self.assertEqual(default_dict_root, {'col:collection': _COLLECTION_DICT})
 
+    def test_visitor_converter(self):
+        visitor_dict = self.col_schema.to_dict(self.col_xml_file, converter=VisitorConverter)
+        self.assertEqual(visitor_dict, _COLLECTION_DICT)
+
+        visitor_dict_root = self.col_schema.to_dict(
+            self.col_xml_file, converter=VisitorConverter(preserve_root=True))
+        self.assertEqual(visitor_dict_root, {'col:collection': _COLLECTION_DICT})
+
     def test_parker_converter(self):
         parker_dict = self.col_schema.to_dict(self.col_xml_file, converter=xmlschema.ParkerConverter)
         self.assertEqual(parker_dict, _COLLECTION_PARKER)
@@ -1259,17 +1268,29 @@ class TestEncoding(XMLSchemaTestCase):
             indent=0,
         )
         self.check_encode(schema.elements['A'], {'B1': 'abc', 'B2': 10, 'B4': False}, XMLSchemaValidationError)
-        self.check_encode(
-            xsd_component=schema.elements['A'],
-            data=ordered_dict_class([('B1', 'abc'), ('B2', 10), ('#1', 'hello'), ('B3', True)]),
-            expected=u'<ns:A xmlns:ns="ns">\n<B1>abc</B1>\n<B2>10</B2>\nhello\n<B3>true</B3>\n</ns:A>',
-            indent=0, cdata_prefix='#'
-        )
-        self.check_encode(
-            xsd_component=schema.elements['A'],
-            data=ordered_dict_class([('B1', 'abc'), ('B2', 10), ('#1', 'hello')]),
-            expected=XMLSchemaValidationError, indent=0, cdata_prefix='#'
-        )
+
+        converter_cls = getattr(self.schema_class, "converter", None)
+        if converter_cls and issubclass(converter_cls, VisitorConverter):
+            # VisitorConverter doesn't use ordered content which makes
+            # it incompatible with cdata.
+            self.check_encode(
+                xsd_component=schema.elements['A'],
+                data=ordered_dict_class([('B1', 'abc'), ('B2', 10), ('#1', 'hello'), ('B3', True)]),
+                expected=XMLSchemaValueError,
+                indent=0, cdata_prefix='#'
+            )
+        else:
+            self.check_encode(
+                xsd_component=schema.elements['A'],
+                data=ordered_dict_class([('B1', 'abc'), ('B2', 10), ('#1', 'hello'), ('B3', True)]),
+                expected=u'<ns:A xmlns:ns="ns">\n<B1>abc</B1>\n<B2>10</B2>\nhello\n<B3>true</B3>\n</ns:A>',
+                indent=0, cdata_prefix='#'
+            )
+            self.check_encode(
+                xsd_component=schema.elements['A'],
+                data=ordered_dict_class([('B1', 'abc'), ('B2', 10), ('#1', 'hello')]),
+                expected=XMLSchemaValidationError, indent=0, cdata_prefix='#'
+            )
 
     def test_encode_datetime(self):
         xs = self.get_schema('<element name="dt" type="dateTime"/>')
@@ -1354,6 +1375,41 @@ class TestEncoding(XMLSchemaTestCase):
 
 class TestEncoding11(TestEncoding):
     schema_class = XMLSchema11
+
+
+class XMLSchemaVisitorConverter(xmlschema.XMLSchema):
+    converter = VisitorConverter
+
+
+class TestEncodingVisitorConverter10(TestEncoding):
+    schema_class = XMLSchemaVisitorConverter
+
+    def test_visitor_converter_sequence_in_sequence(self):
+        schema = self.get_schema("""
+            <element name="foo">
+                <complexType>
+                    <sequence minOccurs="1" maxOccurs="2">
+                        <element name="A" minOccurs="0" type="integer" nillable="true" />
+                        <element name="B" minOccurs="0" type="integer" nillable="true" />
+                    </sequence>
+                </complexType>
+            </element>
+        """)
+        tree = schema.to_etree(
+            {"A": [1, 2], "B": [3, 4]},
+        )
+        vals = []
+        for elem in tree:
+            vals.append(elem.text)
+        self.assertEqual(vals, ['1', '3', '2', '4'])
+
+
+class XMLSchema11VisitorConverter(XMLSchema11):
+    converter = VisitorConverter
+
+
+class TestEncodingVisitorConverter11(TestEncoding):
+    schema_class = XMLSchema11VisitorConverter
 
 
 # Creates decoding/encoding tests classes from XML files

--- a/xmlschema/validators/groups.py
+++ b/xmlschema/validators/groups.py
@@ -639,7 +639,7 @@ class XsdGroup(XsdComponent, ModelGroup, ValidationMixin):
 
         yield result_list
 
-    def order_unordered_content(self, content):
+    def sort_content(self, content):
         """
         Takes a dictionary and returns a list of element name and content tuples.
 
@@ -726,7 +726,7 @@ class XsdGroup(XsdComponent, ModelGroup, ValidationMixin):
         cdata_index = 0
 
         if isinstance(element_data.content, dict):
-            content = self.order_unordered_content(element_data.content)
+            content = self.sort_content(element_data.content)
         else:
             content = element_data.content
 


### PR DESCRIPTION
- Resolves #69
  This approach allows strict encoding and validation of an unordered
  dictionary without having to handle errors.
- Can generate correct xml for repeated sequences of multiple elements:
  {"A": [1, 2], "B": [3, 4]} -> \<A\>1\</A\>\<B\>3\</B\>\<A\>2\</A\>\<B\>4\</B\>
- VisitorConverter raises an Exception if the data being encoded
  contains cdata. The unordered processing of the dict means character
  data may not be placed in the correct locations.
- Reuses existing encoding tests.