### PR TITLE
Use semver for elementpath dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,10 @@ setup(
     version='1.1.0',
     packages=['xmlschema'],
     include_package_data=True,
-    setup_requires=['elementpath~=1.4.0'],
-    install_requires=['elementpath~=1.4.0'],
+    setup_requires=['elementpath~=1.4'],
+    install_requires=['elementpath~=1.4'],
     extra_require={
-        'dev': ['tox', 'coverage', 'lxml', 'elementpath~=1.4.0',
+        'dev': ['tox', 'coverage', 'lxml', 'elementpath~=1.4',
                 'memory_profiler', 'Sphinx', 'sphinx_rtd_theme']
     },
     cmdclass={


### PR DESCRIPTION
`elementpath~=1.4.0` -> >=1.4.0,<1.5.0
`elementpath~=1.4` -> >=1.4,<2.0

For semver, we want to take up til the next major version, which will likely included breaking changes. Minor changes should be forward compatible