### PR TITLE
Raise error for allow="sandbox" when no base_url is provided.

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -423,10 +423,13 @@ class TestResources(unittest.TestCase):
             "block access to files out of sandbox requires 'base_url' to be set",
         )
 
+        source = "/tmp/vehicles.xsd"
         with self.assertRaises(XMLSchemaResourceError) as ctx:
-            XMLResource("/tmp/vehicles.xsd", base_url=base_url, allow='sandbox')
-        self.assertEqual(str(ctx.exception).replace('\\', '/'),
-                         "block access to out of sandbox file /tmp/vehicles.xsd")
+            XMLResource(source, base_url=base_url, allow='sandbox')
+        self.assertEqual(
+            str(ctx.exception),
+            "block access to out of sandbox file {}".format(normalize_url(source)),
+        )
 
         with self.assertRaises(TypeError) as ctx:
             XMLResource("https://xmlschema.test/vehicles.xsd", allow=None)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -398,7 +398,9 @@ class TestResources(unittest.TestCase):
         base_url = resource.base_url
 
         XMLResource(self.vh_xml_file, allow='local')
-        XMLResource(self.vh_xml_file, allow='sandbox')
+        XMLResource(
+            self.vh_xml_file, base_url=os.path.dirname(self.vh_xml_file), allow='sandbox'
+        )
 
         with self.assertRaises(XMLSchemaResourceError) as ctx:
             XMLResource(self.vh_xml_file, allow='remote')
@@ -413,6 +415,13 @@ class TestResources(unittest.TestCase):
             XMLResource("https://xmlschema.test/vehicles.xsd", allow='sandbox')
         self.assertEqual(str(ctx.exception),
                          "block access to remote resource https://xmlschema.test/vehicles.xsd")
+
+        with self.assertRaises(XMLSchemaResourceError) as ctx:
+            XMLResource("/tmp/vehicles.xsd", allow='sandbox')
+        self.assertEqual(
+            str(ctx.exception),
+            "block access to files out of sandbox requires 'base_url' to be set",
+        )
 
         with self.assertRaises(XMLSchemaResourceError) as ctx:
             XMLResource("/tmp/vehicles.xsd", base_url=base_url, allow='sandbox')

--- a/xmlschema/resources.py
+++ b/xmlschema/resources.py
@@ -384,10 +384,8 @@ class XMLResource(object):
                 raise XMLSchemaResourceError(
                     "block access to files out of sandbox requires 'base_url' to be set"
                 )
-            path = os.path.normpath(os.path.normcase(urlsplit(url).path))
-            base_path = os.path.normpath(os.path.normcase(urlsplit(self._base_url).path))
-            if not path.startswith(base_path):
-                raise XMLSchemaResourceError("block access to out of sandbox file {}".format(path))
+            if not url.startswith(normalize_url(self._base_url)):
+                raise XMLSchemaResourceError("block access to out of sandbox file {}".format(url))
 
     def _fromsource(self, source):
         url = None

--- a/xmlschema/resources.py
+++ b/xmlschema/resources.py
@@ -377,9 +377,13 @@ class XMLResource(object):
             raise XMLSchemaResourceError("block access to local resource {}".format(url))
         elif is_remote_url(url):
             raise XMLSchemaResourceError("block access to remote resource {}".format(url))
-        elif self.allow == 'local' or self._base_url is None:
+        elif self.allow == 'local':
             return
         else:
+            if self._base_url is None:
+                raise XMLSchemaResourceError(
+                    "block access to files out of sandbox requires 'base_url' to be set"
+                )
             path = os.path.normpath(os.path.normcase(urlsplit(url).path))
             base_path = os.path.normpath(os.path.normcase(urlsplit(self._base_url).path))
             if not path.startswith(base_path):


### PR DESCRIPTION
Previously when base_url is None it had the behaviour of "local". This
will help people not to forget to supply base_url when using "sandbox".