### PR TITLE
Improve xml.etree namespace cleanup

### DIFF
--- a/xmlschema/etree.py
+++ b/xmlschema/etree.py
@@ -44,6 +44,7 @@ if '_elementtree' in sys.modules:
 
     # Restore original modules
     sys.modules['_elementtree'] = _cmod
+    sys.modules['xml.etree'].ElementTree = ElementTree
     sys.modules['xml.etree.ElementTree'] = ElementTree
 
 else:
@@ -52,6 +53,7 @@ else:
     PyElementTree = importlib.import_module('xml.etree.ElementTree')
 
     # Remove the pure Python module from imported modules
+    del sys.modules['xml.etree']
     del sys.modules['xml.etree.ElementTree']
     del sys.modules['_elementtree']
 


### PR DESCRIPTION
This fixes an oversight in the `xml.etree` namespace cleanup code in `xmlschema.etree`. The existing cleanup code restores `sys.modules['xml.etree.ElementTree']` but doesn't also restore `sys.modules['xml.etree'].ElementTree` (which is a distinct reference). The general result is that code importing `ElementTree` before and after `xmlschema.etree` is imported will see different instances of `ElementTree` and its classes (usually one from the C extension and one from the pure-Python version), which can cause strange and seemingly impossible bugs.

For example pickling an `ElementTree.Element` object raises a nonsensical error (the class names displayed are identical):
> _pickle.PicklingError: Can't pickle <class 'xml.etree.ElementTree.Element'>: it's not the same object as xml.etree.ElementTree.Element

I've also had problems using `Element` as a type annotation that I now think are a result of this issue.

I think these two lines are all that's needed to fix the problem!