### PR TITLE
Fix name of XsdMaxLengthFacet internal function for readability

### DIFF
--- a/xmlschema/validators/facets.py
+++ b/xmlschema/validators/facets.py
@@ -242,9 +242,9 @@ class XsdMaxLengthFacet(XsdFacet):
         primitive_type = getattr(self.base_type, 'primitive_type', None)
         if primitive_type is None or primitive_type.name not in {XSD_QNAME, XSD_NOTATION_TYPE}:
             # See: https://www.w3.org/Bugs/Public/show_bug.cgi?id=4009
-            self._validator = self._min_length_validator  # type: ignore[assignment]
+            self._validator = self._max_length_validator  # type: ignore[assignment]
 
-    def _min_length_validator(self, value: Any) -> None:
+    def _max_length_validator(self, value: Any) -> None:
         if len(value) > self.value:
             reason = "value length cannot be greater than {!r}".format(self.value)
             raise XMLSchemaValidationError(self, value, reason)


### PR DESCRIPTION
The internal validator function in `XsdMaxLengthFacet` appears to have been copy-and-pasted, but the function name was never changed from `_min_length_validator`. This caused me a little bit of trouble debugging, so I thought I would submit this PR to update the name to `_max_length_validator` as would be expected. Thanks!

CC @colosi @StatesTitle (for our own internal visibility)