### PR TITLE
Fix encoding of +/-inf and nan values

### DIFF
--- a/xmlschema/validators/builtins.py
+++ b/xmlschema/validators/builtins.py
@@ -39,7 +39,7 @@ from .helpers import decimal_validator, qname_validator, byte_validator, \
     unsigned_short_validator, unsigned_int_validator, unsigned_long_validator, \
     negative_int_validator, positive_int_validator, non_positive_int_validator, \
     non_negative_int_validator, hex_binary_validator, base64_binary_validator, \
-    error_type_validator, boolean_to_python, python_to_boolean
+    error_type_validator, boolean_to_python, python_to_boolean, python_to_float
 from .facets import XSD_10_FACETS_BUILDERS, XSD_11_FACETS_BUILDERS
 from .simple_types import XsdSimpleType, XsdAtomicBuiltin
 
@@ -334,12 +334,14 @@ XSD_10_BUILTIN_TYPES: Tuple[Dict[str, Any], ...] = XSD_COMMON_BUILTIN_TYPES + (
         'python_type': float,
         'admitted_facets': FLOAT_FACETS,
         'facets': [XSD10_FLOAT_PATTERN_ELEMENT, COLLAPSE_WHITE_SPACE_ELEMENT],
+        'from_python': python_to_float,
     },  # 64 bit floating point
     {
         'name': XSD_FLOAT,
         'python_type': float,
         'admitted_facets': FLOAT_FACETS,
         'facets': [XSD10_FLOAT_PATTERN_ELEMENT, COLLAPSE_WHITE_SPACE_ELEMENT],
+        'from_python': python_to_float,
     },  # 32 bit floating point
 
     # --- Year related primitive types (year 0 not allowed) ---
@@ -379,12 +381,14 @@ XSD_11_BUILTIN_TYPES: Tuple[Dict[str, Any], ...] = XSD_COMMON_BUILTIN_TYPES + (
         'python_type': float,
         'admitted_facets': FLOAT_FACETS,
         'facets': [XSD11_FLOAT_PATTERN_ELEMENT, COLLAPSE_WHITE_SPACE_ELEMENT],
+        'from_python': python_to_float,
     },  # 64 bit floating point
     {
         'name': XSD_FLOAT,
         'python_type': float,
         'admitted_facets': FLOAT_FACETS,
         'facets': [XSD11_FLOAT_PATTERN_ELEMENT, COLLAPSE_WHITE_SPACE_ELEMENT],
+        'from_python': python_to_float,
     },  # 32 bit floating point
 
     # --- Year related primitive types (year 0 allowed and mapped to 1 BCE) ---

--- a/xmlschema/validators/helpers.py
+++ b/xmlschema/validators/helpers.py
@@ -9,7 +9,7 @@
 #
 from decimal import Decimal
 from math import isinf, isnan
-from typing import Optional, Set, Union
+from typing import Optional, Set, SupportsFloat, Union
 from xml.etree.ElementTree import Element
 from elementpath import datatypes
 
@@ -176,3 +176,13 @@ def boolean_to_python(value: str) -> bool:
 
 def python_to_boolean(value: object) -> str:
     return str(value).lower()
+
+
+def python_to_float(value: SupportsFloat) -> str:
+    if isnan(value):
+        return "NaN"
+    if value == float("inf"):
+        return "INF"
+    if value == float("-inf"):
+        return "-INF"
+    return str(value)


### PR DESCRIPTION
Hi,
I've noticed that some special Python float values (+/- inf and nan) were not encoded to their correct XML counterparts which are case-sensitive. I've added an utility function similar to `python_to_boolean` that returns the correct strings for `float("nan")`, `float("inf")` and `float("-inf")` and `str(value)` for regular values.

Although this is out of the scope of this PR, I've also attached a Python script that checks that running decode then encode on an XML file returns the same data. You can run it with:
`python test-decode-encode.py test.xsd test.xml`
The XML file and XML Schema attached are based on a test found in the CodeSynthesis XSD sources ([see here](https://git.codesynthesis.com/cgit/xsd/xsd/tree/xsd-tests/cxx/tree/default/general)) that could be extended to check even more data types. Maybe that could be something worth including into the test suite?

[test.xsd](https://github.com/sissaschool/xmlschema/files/8643443/test.xsd.txt)
[test-decode-encode.py](https://github.com/sissaschool/xmlschema/files/8643444/test-decode-encode.py.txt)
[test.xml](https://github.com/sissaschool/xmlschema/files/8643445/test.xml.txt)