### PR TITLE
doc: creating a local copy of a remote XSD schema for offline use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ This library includes the following features:
 
 * Full XSD 1.0 and XSD 1.1 support
 * Building of XML schema objects from XSD files
+* Downloading XSD files from a remote URL and storing them for offline use
 * Validation of XML instances against XSD schemas
 * Decoding of XML data into Python data and to JSON
 * Encoding of Python data and JSON to XML

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -124,6 +124,39 @@ or similarly to the previous example one can use the method :meth:`xmlschema.XML
     schemas to other XSD validators.
 
 
+Creating a local copy of a remote XSD schema for offline use
+------------------------------------------------------------
+
+Sometimes, it is advantageous to validate XML files using an XSD schema located
+at a remote location while also having the option to store the same schema
+locally for offline use.
+
+.. code-block:: py
+
+    import xmlschema
+    schema = xmlschema.XMLSchema("https://www.omg.org/spec/ReqIF/20110401/reqif.xsd")
+    schema.export(target='my_schemas', save_remote=True)
+    schema = xmlschema.XMLSchema("my_schemas/reqif.xsd")  # works without internet
+
+With these commands, a folder ``my_schemas`` is created and contains the
+XSD files that can be used without access to the internet.
+
+The resulting XSD files are identical to their remote source files, with the
+only difference being that xmlschema transforms the remote URLs into local
+URLs. The ``export`` command bundles a set of a target XSD file and all its
+dependencies by changing the ``schemaLocation`` attributes into
+``xs:import/xs:include`` statements as follows:
+
+.. code-block:: xml
+
+    <xsd:import namespace="http://www.w3.org/1999/xhtml" schemaLocation="http://www.omg.org/spec/ReqIF/20110402/driver.xsd"/>
+
+becomes
+
+.. code-block:: xml
+
+    <xsd:import namespace="http://www.w3.org/1999/xhtml" schemaLocation="my_schemas/www.omg.org/spec/ReqIF/20110402/driver.xsd"/>
+
 Validation
 ==========
 


### PR DESCRIPTION
As discussed [here](https://github.com/sissaschool/xmlschema/issues/360#issuecomment-1661988962), here is my attempt to document the export workflow.

I have included this content in the Usage section because it provides essential information to help someone get started with xmlschema when they wish to store a remote XSD schema for offline use. This basic knowledge can be of good assistance to newcomers.