### PR TITLE
Skip a test case when no internet connection is available

### DIFF
--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -13,6 +13,7 @@ import unittest
 import gettext
 
 from xmlschema import XMLSchema, translation
+from xmlschema.testing import SKIP_REMOTE_TESTS
 
 
 class TestTranslations(unittest.TestCase):
@@ -107,6 +108,7 @@ class TestTranslations(unittest.TestCase):
         finally:
             translation._translation = None
 
+    @unittest.skipIf(SKIP_REMOTE_TESTS, "Remote networks are not accessible.")
     def test_pl_validation_translation(self):
         xml_path = "tests//test_cases//translations//pl//tytul_wykonawczy_niekompletny.xml"
         xsd_path = "tests//test_cases//translations//pl//tw-1(5)8e.xsd"


### PR DESCRIPTION
When trying to build the latest version of xmlschema on Fedora test_pl_validation_translation fails as it requires an internet connection.

<details>
<summary>logs:</summary>

```
test_pl_validation_translation (tests.test_translations.TestTranslations.test_pl_validation_translation) ... /builddir/build/BUILD/xmlschema-2.4.0/tests/test_translations.py:122: XMLSchemaImportWarning: Import of namespace 'http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2020/07/06/eD/DefinicjeTypy/' from ['http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2020/07/06/eD/DefinicjeTypy/StrukturyDanych_v7-0E.xsd'] failed: cannot access to resource 'http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2020/07/06/eD/DefinicjeTypy/StrukturyDanych_v7-0E.xsd': [Errno -3] Temporary failure in name resolution.
  schema = XMLSchema(
/builddir/build/BUILD/xmlschema-2.4.0/tests/test_translations.py:122: XMLSchemaImportWarning: Import of namespace 'http://crd.gov.pl/xml/schematy/struktura/2009/11/16/' from ['http://crd.gov.pl/xml/schematy/struktura/2009/11/16/struktura.xsd'] failed: cannot access to resource 'http://crd.gov.pl/xml/schematy/struktura/2009/11/16/struktura.xsd': [Errno -3] Temporary failure in name resolution.
  schema = XMLSchema(
/builddir/build/BUILD/xmlschema-2.4.0/tests/test_translations.py:122: XMLSchemaImportWarning: Import of namespace 'http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2021/04/14/eTW/Commons/' from ['http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2021/04/14/eTW/Commons/schemat_commons.xsd'] failed: cannot access to resource 'http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2021/04/14/eTW/Commons/schemat_commons.xsd': [Errno -3] Temporary failure in name resolution.
  schema = XMLSchema(
FAIL
```

</details>