### PR TITLE
Set python-requires metadata to >=3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
             'xmlschema-json2xml=xmlschema.cli:json2xml',
         ]
     },
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=['elementpath>=4.1.5, <5.0.0'],
     extras_require={
         'codegen': ['elementpath>=4.1.5, <5.0.0', 'jinja2'],


### PR DESCRIPTION
xmlschema now requires Python >=3.8 but the package metadata did not get updated. This allow pip to pick and install the 3.x release on Python 3.7 and then xmlschema fails at runtime.