### PR TITLE
CLI: Use stdout and stderr to print Messages with xmlschema-validate command

### DIFF
--- a/xmlschema/cli.py
+++ b/xmlschema/cli.py
@@ -269,5 +269,8 @@ def validate():
             else:
                 tot_errors += len(errors)
                 sys.stderr.write(f"{filepath} is not valid\n")
+                if args.verbosity > 0:
+                    for error in errors:
+                        sys.stderr.write(f"{error}\n")
 
     sys.exit(tot_errors)

--- a/xmlschema/cli.py
+++ b/xmlschema/cli.py
@@ -261,13 +261,13 @@ def validate():
                                       locations=args.locations, lazy=args.lazy, defuse=args.defuse))
         except (xmlschema.XMLSchemaException, URLError) as err:
             tot_errors += 1
-            print(str(err))
+            sys.stderr.write(f"{err}\n")
             continue
         else:
             if not errors:
-                print("{} is valid".format(filepath))
+                sys.stdout.write(f"{filepath} is valid\n")
             else:
                 tot_errors += len(errors)
-                print("{} is not valid".format(filepath))
+                sys.stderr.write(f"{filepath} is not valid\n")
 
     sys.exit(tot_errors)


### PR DESCRIPTION
This change affects the "xmlschema-validate" CLI command. The print() statements were changed to stdout and stderr. This helps users to distinguish between error messages and others.

In addition, the -v argument has not yet been used. When -v is specified, a detailed error report is now output, which helps users to find the error in their XML files.