### PR TITLE
Obtain xml import url path without query param

### DIFF
--- a/xmlschema/locations.py
+++ b/xmlschema/locations.py
@@ -57,7 +57,7 @@ class LocationPath(PurePath):
 
         parts = urlsplit(uri)
         if not parts.scheme:
-            return cls(uri)
+            return cls(parts.path)
         elif parts.scheme in DRIVE_LETTERS and len(parts.scheme) == 1:
             return LocationWindowsPath(uri)  # Eg. k:/Python/lib/....
         elif parts.scheme != 'file':


### PR DESCRIPTION
Fixed problem evaluating WSDL files with xml imports containing relative URLs with query params. Code was incorrectly returning full uri rather than just the path and subsequently adding the path a second time. This resulted in the import not being found.