### PR TITLE
use importlib to get package version from pyproject.toml

### DIFF
--- a/xmlschema/__init__.py
+++ b/xmlschema/__init__.py
@@ -7,6 +7,8 @@
 #
 # @author Davide Brunato <brunato@sissa.it>
 #
+from importlib.metadata import version
+
 from elementpath.etree import etree_tostring
 
 from . import limits
@@ -33,7 +35,7 @@ from .validators import (
     XMLSchema, XMLSchema10, XMLSchema11, XsdComponent, XsdType, XsdElement, XsdAttribute
 )
 
-__version__ = '3.4.4'
+__version__ = version("xmlschema")
 __author__ = "Davide Brunato"
 __contact__ = "brunato@sissa.it"
 __copyright__ = "Copyright 2016-2024, SISSA"


### PR DESCRIPTION
In your test_package.py's test_version you compare the versions in
- pyproject.toml
- `__init__.py`
- doc/conf.py

This PR suggests to re-use the defined version from pyproject.toml, which will make that one test case obsolete.

What do you think?