### PR TITLE
Avoid using internal _operator module

### DIFF
--- a/xmlschema/validators/builders.py
+++ b/xmlschema/validators/builders.py
@@ -8,11 +8,11 @@
 # @author Davide Brunato <brunato@sissa.it>
 #
 import copy
-from _operator import itemgetter
 from abc import abstractmethod
 from collections import Counter
 from collections.abc import Callable, ItemsView, Iterator, Mapping, ValuesView, Iterable
 from copy import copy as shallow_copy
+from operator import itemgetter
 from types import MappingProxyType
 from typing import Any, cast, NamedTuple, Optional, Union, Type, TypeVar
 from xml.etree.ElementTree import Element


### PR DESCRIPTION
The `_operator` is CPython internal module that might not be available on other Python implementations, like GraalPy. Use the `operator` module which is the public module providing the same thing.