### PR TITLE
Resolve regex library warnings

### DIFF
--- a/tests/validators/test_xsdbase.py
+++ b/tests/validators/test_xsdbase.py
@@ -53,7 +53,7 @@ class TestXsdValidator(unittest.TestCase):
         tmpl = '<xmlschema.validators.xsdbase.XsdValidator object at {}>'
         string_repr = str(validator)
         if platform.python_implementation() == 'PyPy' or platform.system() == 'Windows':
-            string_repr = re.sub(r'0x[0]+', '0x', string_repr, 1)
+            string_repr = re.sub(r'0x[0]+', '0x', string_repr, count=1)
         self.assertEqual(string_repr.lower(), tmpl.format(hex(id(validator))).lower())
 
     def test_check_validator(self):


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `re` library, which you can find in the [CI logs](https://github.com/sissaschool/xmlschema/actions/runs/15054336085/job/42316554304#step:8:31):
```python
D:\a\xmlschema\xmlschema\tests\validators\test_xsdbase.py:56: DeprecationWarning: 'count' is passed as positional argument
```
