### PR TITLE
📚 Remove Python versions from `README`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ xmlschema
 .. xmlschema-introduction-start
 
 The *xmlschema* library is an implementation of `XML Schema <http://www.w3.org/2001/XMLSchema>`_
-for Python (supports Python 3.8+).
+for Python.
 
 This library arises from the needs of a solid Python layer for processing XML
 Schema based files for
@@ -56,7 +56,7 @@ This library includes the following features:
 Installation
 ============
 
-You can install the library with *pip* in a Python 3.7+ environment::
+You can install the library with *pip* in a Python environment::
 
     pip install xmlschema
 


### PR DESCRIPTION
The supported Python versions in the README seemed inconsistent and outdated. Here we simply remove them from the README, since they are clearly indicated by the badges/metadata.