### PR TITLE
Don't fill prohibited attributes with their value constraint (issue #473)

### DIFF
--- a/tests/validators/test_attributes.py
+++ b/tests/validators/test_attributes.py
@@ -449,6 +449,39 @@ class TestXsdAttributes(XsdValidatorTestCase):
         self.assertEqual(attribute_group['attr2'].value_constraint, 'alpha')
         self.assertEqual(attribute_group['attr3'].value_constraint, 'beta')
 
+    def test_prohibited_attribute_with_fixed_value(self):
+        # See issue #473: a prohibited attribute that also carries a value
+        # constraint (allowed only in XSD 1.0) must not be filled in, otherwise
+        # validation injects the fixed value and then reports a bogus "use of
+        # attribute is prohibited" error for documents that never use it.
+        if self.schema_class.XSD_VERSION != "1.0":
+            return
+
+        schema = self.schema_class("""
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                <xs:complexType name="TypeA" abstract="true">
+                    <xs:attribute name="Attr" use="prohibited" type="xs:string"/>
+                </xs:complexType>
+                <xs:complexType name="TypeB">
+                    <xs:complexContent>
+                        <xs:restriction base="TypeA">
+                            <xs:attribute name="Attr" use="prohibited"
+                                fixed="ValueB" type="xs:string"/>
+                        </xs:restriction>
+                    </xs:complexContent>
+                </xs:complexType>
+                <xs:element name="InstanceDeclB" type="TypeB"/>
+            </xs:schema>""")
+
+        self.assertTrue(schema.is_valid("<InstanceDeclB/>"))
+        self.assertIsNone(schema.to_dict("<InstanceDeclB/>"))
+
+        # the prohibited fixed value is not injected as a value constraint ...
+        attribute_group = schema.types['TypeB'].attributes
+        self.assertListEqual(attribute_group.decode({}), [])
+        # ... but an actual use of the prohibited attribute is still rejected.
+        self.assertFalse(schema.is_valid('<InstanceDeclB Attr="x"/>'))
+
     def test_decoding(self):
         schema = self.check_schema("""
         <xs:attributeGroup name="extra">

--- a/xmlschema/validators/attributes.py
+++ b/xmlschema/validators/attributes.py
@@ -636,13 +636,17 @@ class XsdAttributeGroup(
     def iter_value_constraints(self, use_defaults: bool = True) -> Iterator[tuple[str, str]]:
         if use_defaults:
             for k, v in self._attribute_group.items():
-                if v.fixed is not None and k:
+                if not k or v.use == 'prohibited':
+                    continue
+                if v.fixed is not None:
                     yield k, v.fixed
-                elif v.default is not None and k:
+                elif v.default is not None:
                     yield k, v.default
         else:
             for k, v in self._attribute_group.items():
-                if v.fixed is not None and k:
+                if not k or v.use == 'prohibited':
+                    continue
+                if v.fixed is not None:
                     yield k, v.fixed
 
     def iter_components(self, xsd_classes: ComponentClassType = None) \


### PR DESCRIPTION
## Summary

Fixes #473. Validation reports a spurious `use of attribute 'X' is prohibited` error for documents that never use the attribute, when the schema declares that attribute with `use="prohibited"` *and* a `fixed` value (valid in XSD 1.0):

```python
import xmlschema
schema = xmlschema.XMLSchema("test.xsd")   # TypeB restricts TypeA, re-declaring
schema.to_dict("test.xml")                 # prohibited Attr with fixed="ValueB"
# XMLSchemaValidationError: failed validating {'Attr': 'ValueB'}
#   Reason: use of attribute 'Attr' is prohibited
```

The instance document is empty and uses no attribute. `lxml`/libxml2 and other validators accept it.

## Root cause

`XsdAttributeGroup.iter_value_constraints()` yields the fixed/default value for **every** attribute, including prohibited ones. During decoding, `raw_decode()` therefore injects `{'Attr': 'ValueB'}` into the attribute set as a value constraint, and the subsequent prohibited-use check then flags that injected value — even though the document itself never carried the attribute.

## Fix

Skip prohibited attributes when collecting value constraints. A prohibited attribute has no value to fill in.

Verified:

- Issue #473's schema/document now validates (`is_valid` → `True`, `to_dict` → `None`).
- An *actual* use of the prohibited attribute is still rejected.
- Value filling for non-prohibited `fixed`/`default` attributes is unchanged.
- New regression test `test_prohibited_attribute_with_fixed_value` (XSD 1.0; XSD 1.1 forbids `fixed` with `use="prohibited"` at parse time, so the test is version-guarded). It fails before the change and passes after.
- Full test suite: **1437 passed, 101 skipped**, no regressions. `flake8` and `mypy` clean (no new errors in the touched file).

---

This pull request was prepared with the assistance of AI, under my direction and review.
