### PR TITLE
Fix xs:list empty element decoding to None instead of []

### DIFF
--- a/tests/validation/test_decoding.py
+++ b/tests/validation/test_decoding.py
@@ -1866,6 +1866,36 @@ class TestDecoding11(TestDecoding):
         self.assertTrue(xs.is_valid('<ns:value xmlns:ns="ns" choice="bool">0</ns:value>'))
         self.assertTrue(xs.is_valid('<ns:value xmlns:ns="ns" choice="bool">true</ns:value>'))
 
+    def test_list_type_empty_element_decode(self):
+        """An empty element with a list type should decode to [] like a whitespace-only element."""
+        xsd = """<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+          <xs:simpleType name="intList">
+            <xs:list itemType="xs:integer"/>
+          </xs:simpleType>
+          <xs:element name="v" type="intList"/>
+        </xs:schema>"""
+        schema = self.schema_class(xsd)
+
+        # Both empty and whitespace-only elements should produce the same result.
+        result_empty, _ = schema.to_dict('<v/>', validation='lax')
+        result_ws, _ = schema.to_dict('<v> </v>', validation='lax')
+        self.assertEqual(result_empty, result_ws,
+                         "Empty element and whitespace-only element should decode identically "
+                         "for list types")
+        self.assertEqual(result_empty, [])
+
+        # Encode/decode round-trip for empty list must be identity.
+        import xml.etree.ElementTree as ET
+        encoded = schema.encode([], path='v')
+        xml_str = ET.tostring(encoded).decode()
+        decoded, _ = schema.to_dict(xml_str, validation='lax')
+        self.assertEqual(decoded, [],
+                         "encode([]) -> to_dict round-trip must return []")
+
+        # Non-empty list is unaffected.
+        result_items, _ = schema.to_dict('<v>1 2 3</v>', validation='lax')
+        self.assertEqual(result_items, [1, 2, 3])
+
 
 if __name__ == '__main__':
     from xmlschema.testing import run_xmlschema_tests

--- a/xmlschema/validators/elements.py
+++ b/xmlschema/validators/elements.py
@@ -793,7 +793,7 @@ class XsdElement(XsdComponent, ParticleMixin,
             else:
                 if result is None and context.filler is not None:
                     value = context.filler(self)
-                elif text or context.keep_empty:
+                elif text or context.keep_empty or isinstance(result, list):
                     value = result
 
                 if context.value_hook is not None:


### PR DESCRIPTION
## Summary

For `xs:list` types, an empty element (`<v/>` or `<v></v>`) decoded
to `None` instead of `[]`, while a whitespace-only element (`<v> </v>`)
correctly decoded to `[]`. Both forms are semantically identical under
XSD whitespace collapse rules (both produce an empty token sequence).

The encode→decode round-trip also broke silently: `encode([])` writes
`elem.text = ''` which serialises as `<v />`, and decoding that back
returned `None` instead of `[]`.

## Root cause

`XsdElement.raw_decode` (elements.py line 796) guards value assignment
with:

```python
elif text or context.keep_empty:
    value = result
```

When `elem.text` is `None` (empty element) and `keep_empty=False`, the
condition is `False`, so `value` is never updated from its initial
`None` — even though `raw_decode` already returned `[]` for list types.
A whitespace-only element has `text = ' '` (truthy), so that path
correctly captures the `[]`.

## Fix

Add `or isinstance(result, list)` to the guard so that a list result
is always captured regardless of whether the element carried explicit
text:

```python
elif text or context.keep_empty or isinstance(result, list):
    value = result
```

Scalar types are unaffected: their `raw_decode` never returns a `list`.

## Verification

- `encode([]) → '<v />' → to_dict` round-trip now returns `[]`.
- `<v/>`, `<v></v>`, and `<v> </v>` all decode to `[]` consistently.
- New regression test `test_list_type_empty_element_decode` (RED before
  patch, GREEN after).
- Full test suite: **1535 passed, 1 skipped**, no regressions.

This pull request was prepared with the assistance of AI, under my direction and review.